### PR TITLE
Bugfix - Systems Exploit tab: ignore extra factories if colony has more than max

### DIFF
--- a/src/rotp/model/colony/Colony.java
+++ b/src/rotp/model/colony/Colony.java
@@ -142,6 +142,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
         // production vs its maximum possible formula
         float factories = industry().factories();
         float maxFactories = industry().maxFactories();
+        factories = factories > maxFactories ? maxFactories : factories;
         float pop = population();
         float maxPop = planet().maxSize();
         


### PR DESCRIPTION
Sometimes there is a colony with more factories than the maximum. Such as a planet captured from a race that has higher robotic controls than you, or a recolonized planet that was eaten by a space monster.

The bug: when the colony has less than the max population, the Exploit tab can still say that it is "at maximum production capacity." This is inaccurate, since it has (more than) enough factories, but not enough population to work them.

For testing, see the save in the attached zip (for example, the colony Nazin).

[Silicoid - Small - Harder 1f.zip](https://github.com/rayfowler/rotp-public/files/4549008/Silicoid.-.Small.-.Harder.1f.zip)