### PR TITLE
Correctly show a colony's expected growth even when at "clean."

### DIFF
--- a/src/rotp/model/colony/ColonyEcology.java
+++ b/src/rotp/model/colony/ColonyEcology.java
@@ -283,12 +283,13 @@ public class ColonyEcology extends ColonySpendingCategory {
         if (newBC < cost) 
             return text(wasteText);
         
+        expectedPopGrowth = (int) (workingPop+expGrowth) - (int) currentPop;
+        
         if (colony().allocation(categoryType()) == 0)
             return text(noneText);
         if (allocation() == cleanupAllocationNeeded())
             return text(cleanupText);
 
-        expectedPopGrowth = (int) (workingPop+expGrowth) - (int) currentPop;
         newBC -= cost;
         // check for atmospheric terraforming
         cost = 0;


### PR DESCRIPTION
If eco spending was set at "none" or "clean", the expected growth shown
on the eco slider was always "+0" even if the population would grow
naturally.