### PR TITLE
Fixed spending calculations used by AI and a minor issue with next turn logic in defenses

### DIFF
--- a/src/rotp/model/colony/ColonyIndustry.java
+++ b/src/rotp/model/colony/ColonyIndustry.java
@@ -211,7 +211,7 @@ public class ColonyIndustry extends ColonySpendingCategory {
             //after refitting, build up to max useable factories at current robot controls level
             factoriesToBuild = max(0, maxBuildableFactories(colonyControls)-factories-possibleNewFactories);
             if (factoriesToBuild > 0) {
-                costPerFactory = newFactoryCost();
+                costPerFactory = tech().newFactoryCost(colonyControls);
                 float buildCost = factoriesToBuild * costPerFactory;
                 float bcSpent = Math.min(newBC, buildCost);
                 possibleNewFactories += (bcSpent/costPerFactory);

--- a/src/rotp/model/colony/ColonyIndustry.java
+++ b/src/rotp/model/colony/ColonyIndustry.java
@@ -258,14 +258,23 @@ public class ColonyIndustry extends ColonySpendingCategory {
 
         refitFactoriesCost = Math.max(0, refitFactoriesCost);
         newFactoriesCost = Math.max(0, newFactoriesCost);
-        return Math.max(0, convertFactoriesCost + refitFactoriesCost + newFactoriesCost - industryReserveBC);
+        float totalCost = Math.max(0, convertFactoriesCost + refitFactoriesCost + newFactoriesCost - industryReserveBC);
+
+        // adjust cost for planetary production
+        // assume any amount over current production comes from reserve (no adjustment)
+        float totalBC = (colony().totalProductionIncome() * planet().productionAdj()) + colony().maxReserveIncome();
+        if (totalCost > totalBC)
+            totalCost += colony().totalProductionIncome() * (1 - planet().productionAdj());
+        else
+            totalCost *= colony().totalIncome() / totalBC;
+
+        return totalCost;
     }
     public int maxAllocationNeeded() {
         float needed = maxSpendingNeeded();
         if (needed <= 0)
             return 0;
-        float prod = (colony().totalProductionIncome() * planet().productionAdj()) + colony().maxReserveIncome();
-        float pctNeeded = min(1, needed / prod);
+        float pctNeeded = min(1, needed / colony().totalIncome());
         int ticks = (int) Math.ceil(pctNeeded * MAX_TICKS);
         return ticks;
     }   

--- a/src/rotp/model/colony/ColonyShipyard.java
+++ b/src/rotp/model/colony/ColonyShipyard.java
@@ -293,13 +293,25 @@ public class ColonyShipyard extends ColonySpendingCategory {
         }
     }
     public float maxSpendingNeeded() {
+        float totalCost = 0;
         if (buildingStargate)
-            return max(0, design.cost() - stargateBC);
+            totalCost = max(0, design.cost() - stargateBC);
+        else {
+            float shipCost = design.cost() * desiredShips;
+            if (design == prevDesign)
+                shipCost -= shipBC;
 
-        float shipCost = design.cost() * desiredShips;
-        if (design == prevDesign)
-            shipCost -= shipBC;
+            totalCost = max(0, shipCost);
+        }
 
-        return max(0, shipCost);
+        // adjust cost for planetary production
+        // assume any amount over current production comes from reserve (no adjustment)
+        float totalBC = (colony().totalProductionIncome() * planet().productionAdj()) + colony().maxReserveIncome();
+        if (totalCost > totalBC)
+            totalCost += colony().totalProductionIncome() * (1 - planet().productionAdj());
+        else
+            totalCost *= colony().totalIncome() / totalBC;
+
+        return totalCost;
     }
 }


### PR DESCRIPTION
This is another iteration on what I sent last time.  I looked more deeply at the AIGovernor and AITreasurer files and figured out that the maxSpendingNeeded value needs to be adjusted for planetary production properly for defenses, industry, and shipyard.  Here's a full list of what each change does:

**Defenses:**

- No longer calculates upgrade cost when there are no bases during next turn.
- No longer uses 0.5 BC out of the empire treasury when no spending is allocated to defenses and there is an upgrade available (this even happened for 1 turn when there were no bases)
- maxSpendingNeeded now includes missile base upgrade cost
- maxSpendingNeeded now adjusts for planet type proportionally based on production vs reserve income. Amounts over total current production are not adjusted so additional reserve spending will be on target.  It was not adjusted proportionally before.
- maxAllocationNeeded no longer adjusts for planet type since the maxSpendingNeeded number is already adjusted (it was being adjusted twice, leading to incorrect values).

**Industry:**

- My last fix had maxSpendingNeeded as not adjusted for planet while maxAllocationNeeded was adjusted.  I've changed it to have the adjusted number from maxSpendingNeeded and then maxAllocationNeeded does not need to adjust it again.  This should help the AIGovernor in allocation and the AITreasurer in spending reserve.
- Added fix for upcomingResult to use correct factory cost for factories built after a refit.  It was displaying too many factories to be built after a refit.

**Shipyard:**

- maxSpendingNeeded now adjusts for planet type proportionally based on production vs reserve income. Amounts over total current production are not adjusted so additional reserve spending will be on target.  It was not adjusted at all before.
