### PR TITLE
Fixed converted factories to not generate waste while being converted.

### DIFF
--- a/src/rotp/model/colony/ColonyIndustry.java
+++ b/src/rotp/model/colony/ColonyIndustry.java
@@ -292,6 +292,6 @@ public class ColonyIndustry extends ColonySpendingCategory {
         // select random race from alienFactories and convert 1 factory
         int randomEmpId = p.randomAlienFactoryEmpire();
         p.addAlienFactories(randomEmpId, -1);
-        factories++;
+        newFactories++;
     }
 }


### PR DESCRIPTION
When you convert alien factories, they generate waste during the next turn phase when they are converted.  This fixes that so they will only generate waste on following turns like newly built factories.