### PR TITLE
Fix to recalculate all 6 designs on next turn.

### DIFF
--- a/src/rotp/model/ships/ShipDesignLab.java
+++ b/src/rotp/model/ships/ShipDesignLab.java
@@ -167,11 +167,9 @@ public class ShipDesignLab implements Base, Serializable {
         // update opp shield level (for fighter designs)
         bestEnemyShieldLevel = empire.bestEnemyShieldLevel();
         bestEnemyPlanetaryShieldLevel = empire.bestEnemyPlanetaryShieldLevel();
-        scoutDesign().recalculateCost();
-        colonyDesign().recalculateCost();
-        fighterDesign().recalculateCost();
-        destroyerDesign().recalculateCost();
-        bomberDesign().recalculateCost();
+        for (ShipDesign d : designs) {
+            d.recalculateCost();
+        }
     }
     public void recordConstruction(Design d, int num) {
         ShipView sv = shipViewFor((ShipDesign)d);


### PR DESCRIPTION
6th ship slot for the player is not recalculating during the next turn phase.  I'm not sure how/if this is affecting AI players, but this should ensure that all designs are recalculated each turn.