### PR TITLE
Automatic backup creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ nbproject
 test
 build
 build.xml
-manifest.mf
+manifest.mftarget
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ nbproject
 test
 build
 build.xml
-manifest.mftarget
+manifest.mf
 .idea
+target

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build.xml
 manifest.mf
 .idea
 target
+rotp.iml

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.itch.rayfowler</groupId>
+    <artifactId>rotp</artifactId>
+    <version>1.13b</version>
+
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+        <resources>
+            <resource>
+                <directory>src</directory>
+                <includes>
+                    <include>**/*.txt</include>
+                    <include>**/*.wav</include>
+                    <include>**/*.jpg</include>
+                    <include>**/*.png</include>
+                    <include>**/*.otf</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>rotp.Rotp</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Hi,

I added a "hook" to `saveRecentSession`. Before actually saving the session, it now calls `autoBackup`, which copies the previous _Recent.rotp_ to a new file, before the current session gets saved to it. This backup creation occurs on every fifth game turn. The autosave file's naming scheme contains the save moment timestamp in UTC.

This tries to mimic Stellaris' autosaves, which I've found very handy, when run into a problem, and I want to check if my decisions would've changed the outcome. Or when I bump into the zero-research-bug(?), I can see if a previous autosave will save the future.