### PR TITLE
Multiplayer1

### DIFF
--- a/src/rotp/Rotp.java
+++ b/src/rotp/Rotp.java
@@ -72,8 +72,11 @@ public class Rotp {
 
         setFrameSize();
 
-        if (reloadRecentSave) 
+        if (reloadRecentSave) {
+            RotPUI.instance().unregisterOnSession(GameSession.instance());
             GameSession.instance().loadRecentSession(false);
+            RotPUI.instance().registerOnSession(GameSession.instance());
+        }
         frame.setResizable(false);
         frame.setVisible(true);
     }

--- a/src/rotp/ui/RotPUI.java
+++ b/src/rotp/ui/RotPUI.java
@@ -239,6 +239,9 @@ public class RotPUI extends BasePanel implements ActionListener, KeyListener, Ga
         gameSession.removeGameListener(this);
         gameSession.addGameListener(this);
     }
+    public final void unregisterOnSession(GameSession gameSession) {
+        gameSession.removeGameListener(this);
+    }
     @Override
     public void clearAdvice() {
         RotPUI.this.mainUI().clearAdvice();

--- a/src/rotp/ui/game/GameUI.java
+++ b/src/rotp/ui/game/GameUI.java
@@ -539,8 +539,11 @@ public class GameUI  extends BasePanel implements MouseListener, MouseMotionList
     public void continueGame() {
         if (canContinue()) {
             buttonClick();
-            if (!session().status().inProgress())
+            if (!session().status().inProgress()) {
+                RotPUI.instance().unregisterOnSession(session());
                 session().loadRecentSession(true);
+                RotPUI.instance().registerOnSession(session());
+            }
             RotPUI.instance().selectMainPanel();
         }
     }

--- a/src/rotp/ui/game/LoadGameUI.java
+++ b/src/rotp/ui/game/LoadGameUI.java
@@ -237,7 +237,11 @@ public final class LoadGameUI  extends BasePanel implements MouseListener, Mouse
         loading = true;
         repaint();
         buttonClick();
-        final Runnable load = () -> { GameSession.instance().loadRecentSession(false); };
+        final Runnable load = () -> {
+            RotPUI.instance().unregisterOnSession(session());
+            GameSession.instance().loadRecentSession(false);
+            RotPUI.instance().registerOnSession(session());
+        };
         SwingUtilities.invokeLater(load);
     }
     public void loadGame(String s) {
@@ -248,6 +252,7 @@ public final class LoadGameUI  extends BasePanel implements MouseListener, Mouse
         repaint();
         buttonClick();
         final Runnable load = () -> {
+            RotPUI.instance().unregisterOnSession(session());
             GameSession.instance().loadSession(s, false);
             RotPUI.instance().registerOnSession(session());
         };


### PR DESCRIPTION
Fix for "continue" problem. Continue would not register the ROTP UI as a listener to newly loaded GameSession prior to this fix. Fixed several other locations (like command line option to load a save game) as well. Also added attempt to unregister ROTP UI as a listener to old session before new one being loaded. GC should take care of that anyway but better clean up manually I guess.