### PR TITLE
Dev-AI Improvements

### DIFF
--- a/src/rotp/model/ai/base/AIDiplomat.java
+++ b/src/rotp/model/ai/base/AIDiplomat.java
@@ -1300,7 +1300,7 @@ public class AIDiplomat implements Base, Diplomat {
         pct = cv1.embassy().relations()/100.0f + civ1.race().councilBonus() + civ1.orionCouncilBonus() + previousVoteBonus(civ1) + powerBonus1;
         if (random() <= Math.abs(pct)) {
             if (pct > 0)
-                return castVoteFor(cv1);
+                return castVoteFor(civ1);
         }
 
         // decide to vote for civ2
@@ -1308,7 +1308,7 @@ public class AIDiplomat implements Base, Diplomat {
         pct = cv2.embassy().relations()/100.0f + civ2.race().councilBonus() + civ2.orionCouncilBonus() + previousVoteBonus(civ2) + powerBonus2;
         if (random() <= Math.abs(pct)) {
             if (pct > 0)
-                return castVoteFor(cv2);
+                return castVoteFor(civ2);
         }
 
         // return undecided

--- a/src/rotp/model/ai/base/AIDiplomat.java
+++ b/src/rotp/model/ai/base/AIDiplomat.java
@@ -204,7 +204,12 @@ public class AIDiplomat implements Base, Diplomat {
 
         if (v.embassy().tooManyRequests())
             return v.refuse(DialogueManager.DECLINE_ANNOYED);
-
+        
+        // modnar: add in readyForTech check, limits one tech trade per turn per empire
+        // this also prevents trading the same tech multiple times to the same empire
+        if (!v.embassy().readyForTech())
+            return v.refuse(DialogueManager.DECLINE_OFFER);
+        
         v.embassy().resetTechTimer();
 
         List<Tech> counterTechs = empire.diplomatAI().techsRequestedForCounter(diplomat, tech);
@@ -1124,6 +1129,10 @@ public class AIDiplomat implements Base, Diplomat {
             beginErraticWar(view);
             return true;
         }
+        // modnar: less likely war when already in some wars
+        // asymptotic x/(1+abs(x))
+        if (empire.numEnemies()/(1+Math.abs(empire.numEnemies())) > random())
+            return false;
         // automatic war of hate if relations less < -90
         // and not currently in a timed peace treaty
         if (wantToDeclareWarOfHate(view)){
@@ -1145,6 +1154,11 @@ public class AIDiplomat implements Base, Diplomat {
         
         // from -70 to -90
         float warThreshold = v.empire().leader().hateWarThreshold();
+        
+        // modnar: change war threshold by number of our wars vs. number of their wars
+        // try not to get into too many wars, and pile on if target is in many wars
+        float enemyMod = (float) (10 * (v.empire().numEnemies() - empire.numEnemies()));
+        warThreshold += enemyMod;
         
         // allied with an enemy? not good
         if (v.embassy().alliedWithEnemy())
@@ -1169,6 +1183,11 @@ public class AIDiplomat implements Base, Diplomat {
         && (v.embassy().pact() ||v.embassy().alliance()))
             return false;
         
+        // modnar: less likely war when already in some wars
+        // asymptotic x/(1+abs(x))
+        if (empire.numEnemies()/(1+Math.abs(empire.numEnemies())) > random())
+            return false;
+        
         // don't declare if we have no spy data or data is too old
         int reportAge = v.spies().reportAge();
         if ((reportAge < 0) || (reportAge > 10))
@@ -1178,15 +1197,29 @@ public class AIDiplomat implements Base, Diplomat {
         // keep their power ratios from wildly fluctuating early in the game when
         // everyone has small fleets, so that wars aren't triggered because I have 
         // 4 fighters and you have 1.
-        int basePower = 500;
+        // modnar: reduce basePower due to other changes (techMod, enemyMod)
+        int basePower = 200;
         
         float otherPower = basePower+v.owner().militaryPowerLevel(v.empire());
         float myPower = basePower+v.owner().militaryPowerLevel();
         
-        
-        float baseThreshold = v.owner().atWar() ? 20.0f : 10.0f;
+        // modnar: due to other changes (techMod, enemyMod), reduce baseThreshold
+        float baseThreshold = v.owner().atWar() ? 8.0f : 4.0f;
         float treatyMod = v.embassy().pact() || v.embassy().alliance() ? 1.5f : 1.0f;
-        float warThreshold = baseThreshold *  treatyMod * v.owner().leader().exploitWeakerEmpiresRatio();
+        
+        // modnar: factor in own empire average tech level
+        // suppress war in early game when average tech level is below 8
+        float myTechLvl = v.owner().tech().avgTechLevel(); // minimum average tech level is 1.0
+        float techMod = 1.0f;
+        if (myTechLvl < 8.0f) {
+            techMod = 8.0f / myTechLvl; // inverse change with tech level (range from 8.0 to 1.0)
+        }
+        
+        // modnar: scale war threshold by number of our wars vs. number of their wars
+        // try not to get into too many wars, and pile on if target is in many wars
+        float enemyMod = (float) ((empire.numEnemies() + 1) / (v.empire().numEnemies() + 1));
+        
+        float warThreshold = baseThreshold * techMod * enemyMod * treatyMod * v.owner().leader().exploitWeakerEmpiresRatio();
         
         return (myPower/otherPower) > warThreshold;
     }
@@ -1261,23 +1294,21 @@ public class AIDiplomat implements Base, Diplomat {
         // powerBonus1/powerBonus2 vary from 0 to 1
         float powerBonus1 = (empire.militaryPowerLevel(civ1) + empire.industrialPowerLevel(civ1)) / allEmpirePower;
         float powerBonus2 = (empire.militaryPowerLevel(civ2) + empire.industrialPowerLevel(civ2)) / allEmpirePower;
-		
-        // decide to vote for/against civ1
+        
+        // decide to vote for civ1
+        // modnar: don't force vote for civ2 if civ1 get the negative check
         pct = cv1.embassy().relations()/100.0f + civ1.race().councilBonus() + civ1.orionCouncilBonus() + previousVoteBonus(civ1) + powerBonus1;
         if (random() <= Math.abs(pct)) {
             if (pct > 0)
-                return conditionallyCastVoteFor(cv1);
-            else
-                return conditionallyCastVoteFor(cv2);
+                return castVoteFor(cv1);
         }
 
-        // decide to vote for/against civ2
+        // decide to vote for civ2
+        // modnar: don't force vote for civ1 if civ2 get the negative check
         pct = cv2.embassy().relations()/100.0f + civ2.race().councilBonus() + civ2.orionCouncilBonus() + previousVoteBonus(civ2) + powerBonus2;
         if (random() <= Math.abs(pct)) {
             if (pct > 0)
-                return conditionallyCastVoteFor(cv2);
-            else
-                return conditionallyCastVoteFor(cv1);
+                return castVoteFor(cv2);
         }
 
         // return undecided
@@ -1298,6 +1329,12 @@ public class AIDiplomat implements Base, Diplomat {
             c.defyRuling(empire);
     }
     private boolean giveLoyaltyTo(Empire c) {
+        // modnar: add empire power bonus relative to own power for accepting winner
+        // only what own empire can see (through spies)
+        // more likely to accept more powerful empire, less likely to accept less powerful empire
+        // powerBonus vary from -0.25 to 0.25
+        float powerBonus = 0.5f * (empire.powerLevel(c) / (empire.powerLevel(c) + empire.powerLevel(empire)) - 0.5f);
+        
         if (empire.lastCouncilVoteEmpId() == c.id)
             return true;
 
@@ -1314,19 +1351,19 @@ public class AIDiplomat implements Base, Diplomat {
         
         if (cv1.embassy().anyWar()) {
             if (empire.leader().isXenophobic())
-                return false;
+                return random() < powerBonus; // modnar: add powerBonus
             else if (empire.leader().isAggressive())
-                return random() < 0.5f;
+                return random() < 0.50f + powerBonus; // modnar: add powerBonus
             else
-                return random() < 0.75f;
+                return random() < 0.75f + powerBonus; // modnar: add powerBonus
         }
         
         if (empire.leader().isXenophobic())
-            return random() < 0.50f;
+            return random() < 0.50f + powerBonus; // modnar: add powerBonus
         else if (empire.leader().isErratic())
-            return random() < 0.75f;
+            return random() < 0.75f + powerBonus; // modnar: add powerBonus
 
-        return random() < 0.90f;
+        return random() < 0.90f + powerBonus; // modnar: add powerBonus
     }
     // ----------------------------------------------------------
 // PRIVATE METHODS
@@ -1387,7 +1424,29 @@ public class AIDiplomat implements Base, Diplomat {
         int allSystems = gal.numColonizedSystems();
         int numCivs = gal.numActiveEmpires();
 
-        int maxSystemsWithoutPenalty = max(5, (allSystems /numCivs)+1);
+        // modnar: scale expansion penalty with ~1/[(numCivs)^(0.75)] rather than 1/numCivs
+        // this allows empires to be somewhat bigger than average before the diplomatic size penalty kicks in
+        // not linear with numCivs to account for expected fluctuation of empire sizes with larger number of empires
+        // at the max number of empires (50), you can be ~2 times as large as average before being penalized
+        // use a denominator coefficient factor of ~1.44225 (3^(1/3)) to maps the expression
+        // back to the equal 1/3 "share" of planets when only three empires are remaining
+        // (and when only two are remaining, they won't like you even if you have slightly less planets than they do)
+        //
+        // numCivs(X)   1/X     1/[(1.44225*X)^(0.75)]
+        //      2       50.00%  45.18%
+        //      3       33.33%  33.33%
+        //      4       25.00%  26.86%
+        //      5       20.00%  22.72%
+        //      6       16.67%  19.82%
+        //      8       12.50%  15.97%
+        //      10      10.00%  13.51%
+        //      15      6.67%   9.97%
+        //      20      5.00%   8.03%
+        //      30      3.33%   5.93%
+        //      50      2.00%   4.04%
+        //
+        //int maxSystemsWithoutPenalty = max(5, (allSystems /numCivs)+1);
+        int maxSystemsWithoutPenalty = max(5, (int) Math.ceil(allSystems / Math.pow(1.44225*numCivs, 0.75)));
 
         if (numberSystems > maxSystemsWithoutPenalty)
             events.add(ExpansionIncident.create(view,numberSystems, maxSystemsWithoutPenalty));
@@ -1503,16 +1562,21 @@ public class AIDiplomat implements Base, Diplomat {
         if (v.embassy().finalWar())
             return false;
         
+        // modnar: scale warWeary by number of our wars vs. number of their wars
+        // more weary (willing to take less losses) if we are in more wars than they are
+        // willing to take at least 15% losses
+        float enemyMod = (float) ((empire.numEnemies() + 10) / (v.empire().numEnemies() + 10));
+        
         Empire emp = v.owner();
         TreatyWar treaty = (TreatyWar) v.embassy().treaty();
-        if (treaty.colonyChange(emp) < warColonyLossLimit(v))
+        if (treaty.colonyChange(emp) < (int)Math.min(0.85, enemyMod*warColonyLossLimit(v)))
             return true;
-        if (treaty.populationChange(emp) < warPopulationLossLimit(v))
-            return true;       
-        if (treaty.factoryChange(emp) < warFactoryLossLimit(v))
-            return true;  
-        if (treaty.fleetSizeChange(emp) < warFleetSizeLossLimit(v))
-            return true;  
+        if (treaty.populationChange(emp) < (int)Math.min(0.85, enemyMod*warPopulationLossLimit(v)))
+            return true;
+        if (treaty.factoryChange(emp) < (int)Math.min(0.85, enemyMod*warFactoryLossLimit(v)))
+            return true;
+        if (treaty.fleetSizeChange(emp) < (int)Math.min(0.85, enemyMod*warFleetSizeLossLimit(v)))
+            return true;
 
         // for pop, factories and ships, calculate the pct lost vs the
         // pct we were willing to lose (1-limit). If any of those are >1

--- a/src/rotp/model/ai/base/AIFleetCommander.java
+++ b/src/rotp/model/ai/base/AIFleetCommander.java
@@ -178,7 +178,7 @@ public class AIFleetCommander implements Base, FleetCommander {
         // if this is a staged plan and is unfilled by fleet at staging point, all future ships go to staging point
         if (fPlan.isStaged() && fPlan.needsShips()) {
             ShipFleet stagingFleet = empire.sv.orbitingFleet(fPlan.stagingPointId);
-            if (fPlan.canBeFilledBy(stagingFleet)) 
+            if (fPlan.canBeFilledBy(stagingFleet)) {
                 fPlan.subtract(stagingFleet.orders());
 				
 				// modnar: if the fleet plan can be filled, fill and send out right away

--- a/src/rotp/model/ai/base/AIFleetCommander.java
+++ b/src/rotp/model/ai/base/AIFleetCommander.java
@@ -72,7 +72,7 @@ public class AIFleetCommander implements Base, FleetCommander {
     }
     @Override
     public boolean inExpansionMode() {
-        return empire.tech().shipRange() < 5;
+        return ((empire.tech().shipRange() < 5) || (empire.contacts().isEmpty())); // modnar: keep in expansion mode if not in any contact
     }
     @Override
     public float transportPriority(StarSystem sv) {
@@ -180,6 +180,11 @@ public class AIFleetCommander implements Base, FleetCommander {
             ShipFleet stagingFleet = empire.sv.orbitingFleet(fPlan.stagingPointId);
             if (fPlan.canBeFilledBy(stagingFleet)) 
                 fPlan.subtract(stagingFleet.orders());
+				
+				// modnar: if the fleet plan can be filled, fill and send out right away
+				// may conflict with other priorities, but trade-off for combined multi-design fleets
+				fPlan.fillFrom(stagingFleet);
+			}
             else
                 fPlan.switchToStagingPoint();
         }

--- a/src/rotp/model/ai/base/AIGeneral.java
+++ b/src/rotp/model/ai/base/AIGeneral.java
@@ -34,6 +34,7 @@ import rotp.util.Base;
 public class AIGeneral implements Base, General {
     private final Empire empire;
     private float civProd = 0;
+    private float civTech = 0;
     private final HashMap<StarSystem, List<Ship>> targetedSystems;
     private final List<StarSystem> rushDefenseSystems;
     private final List<StarSystem> rushShipSystems;
@@ -56,6 +57,7 @@ public class AIGeneral implements Base, General {
     @Override
     public void nextTurn() {
         civProd = empire.totalPlanetaryProduction();
+        civTech = empire.tech().avgTechLevel();
         resetTargetedSystems();
         rushDefenseSystems.clear();
         rushShipSystems.clear();
@@ -63,7 +65,70 @@ public class AIGeneral implements Base, General {
         Galaxy gal = galaxy();
         for (int id=0;id<empire.sv.count();id++) 
             reviseFleetPlan(gal.system(id));
-   }
+    }
+    
+    // modnar: adjustments to invasion valuation
+    // Desire value to invade planet, factor in both planet size and factories
+    // Higher desire value for Rich, Ultra-Rich, Artifacts
+    // Lower desire value for Poor, Ultra-Poor
+    public float takePlanetValue(StarSystem sys) {
+        int sysId = sys.id;
+        if (!empire.sv.inShipRange(sysId))  return 0.0f;
+        if (!empire.sv.isScouted(sysId))    return 0.0f;
+        if (!empire.sv.isColonized(sysId))  return 0.0f;
+        
+        float size = empire.sv.currentSize(sysId); // planet size
+        float fact = empire.sv.factories(sysId); // factory count
+        
+        // increase planet value depending on size and factories (val is normalized below)
+        // (4*pow(SIZE, 0.7) + min(20, sqrt(FACTORIES)))
+        // min(20) is ballpark max invasion tech chances (400 factories)
+        // 
+        // Normal,   size-100,    0 factories:  val = 100
+        // Normal,   size-100,  100 factories:  val = 110
+        // Normal,   size-100,  200 factories:  val = 115
+        // Normal,   size-100,  300 factories:  val = 118
+        // Normal,   size-100,  400 factories:  val = 120
+        // Normal,   size-140,  560 factories:  val = 147
+        // Normal,   size-220, 1540 factories:  val = 194
+        // Normal,   size-70,   140 factories:  val =  90
+        // Normal,   size-70,   210 factories:  val =  93
+        // Poor,     size-100,    0 factories:  val =  75
+        // Poor,     size-100,  200 factories:  val =  86
+        // Rich,     size-50,    50 factories:  val = 138
+        // Artifact, size-80,   240 factories:  val = 203
+        float val = (float) (4.0f*Math.pow(size, 0.7f) + Math.min(20.0f, Math.sqrt(fact)));
+
+        // Higher desire value for Rich, Ultra-Rich, Artifacts
+        // Lower desire value for Poor, Ultra-Poor
+        // modnar: increase values for poor/ultra-poor
+        if (empire.sv.isUltraPoor(sysId))
+            val *= 0.6;
+        else if (empire.sv.isPoor(sysId))
+            val *= 0.75;
+        else if (empire.sv.isResourceNormal(sysId))
+            val *= 1;
+        else if (empire.sv.isRich(sysId))
+            val *= 2;
+        else if (empire.sv.isUltraRich(sysId))
+            val *= 3;
+
+        //float for artifacts, triple for super-artifacts
+        if (empire.sv.isArtifact(sysId))
+            val *= 2;
+        else if (empire.sv.isOrionArtifact(sysId))
+            val *= 3;
+        
+        // modnar: killer instinct
+        // higher value for the last few planets of an empire
+        int remainingSystems = galaxy().empire(empire.sv.empId(sysId)).numColonies();
+        if (remainingSystems <=4) {
+            val *= ((remainingSystems + 7)/(remainingSystems + 1));
+        }
+        
+        // modnar: normalized to normal size-100 planet with 200 factories (115)
+        return val/115;
+    }
     @Override
     public float invasionPriority(StarSystem sys) {
         int sysId = sys.id;
@@ -71,9 +136,17 @@ public class AIGeneral implements Base, General {
         if (!empire.sv.isScouted(sysId))    return 0.0f;
         if (!empire.sv.isColonized(sysId))  return 0.0f;
         if (!empire.canColonize(sys.planet()))  return 0.0f;
-
-        float pr = empire.sv.currentSize(sysId);
-
+        
+        // modnar: increase invasion priority with planet size and factory count
+        float pr = empire.sv.currentSize(sysId) + empire.sv.factories(sysId)/20.0f;
+        
+        // modnar: killer instinct
+        // higher priority to take out the last few planets of an empire
+        int remainingSystems = galaxy().empire(empire.sv.empId(sysId)).numColonies();
+        if (remainingSystems <=3) {
+            pr *= ((remainingSystems + 7)/(remainingSystems + 1));
+        }
+        
         if (empire.sv.isPoor(sysId))
             pr *= 2;
         else if (empire.sv.isResourceNormal(sysId))
@@ -136,11 +209,16 @@ public class AIGeneral implements Base, General {
                 setRepelFleetPlan(sys, enemyFleetSize);
             else if (targetedSystems.keySet().contains(sys))
                 setInterceptFleetPlan(sys, enemyFleetSize);
-            else if (empire.sv.isAttackTarget(sysId))
-                setMinimumFighterGuard(sys, FleetPlan.GUARD_ATTACK_TARGET+value);
+            
+            // modnar: stop double fleetplan when enemy is in orbit of colony
+            else if (empire.sv.isAttackTarget(sysId) && !enemyFleetInOrbit)
+                // modnar: if under attack, more fighters on top of missle bases
+                setHighFighterGuard(sys, FleetPlan.GUARD_ATTACK_TARGET+value);
             else if (empire.sv.isBorderSystem(sysId))
-                setMinimumFighterGuard(sys, FleetPlan.GUARD_BORDER_COLONY+value);
+                // modnar: if on border, slightly more fighters
+                setNormalFighterGuard(sys, FleetPlan.GUARD_BORDER_COLONY+value);
             else
+                // modnar: for inner system, minimum fighter guard adjusted lower
                 setMinimumFighterGuard(sys, FleetPlan.GUARD_INNER_COLONY+value);
             return;
         }
@@ -184,7 +262,11 @@ public class AIGeneral implements Base, General {
             return false;
         float pop = empire.sv.population(sys.id);
         float needed = troopsNecessaryToTakePlanet(v, sys);   
-        return needed < pop;
+        // modnar: scale back willingness to take losses
+        // Willing to take 1.1:1 losses to invade normal 100-pop size planet with 200 factories.
+        // For invading normal 80-pop size planet with 320 factories, be willing to take ~1:1 losses.
+        float value = takePlanetValue(sys) * 1.1f;
+        return needed < pop * value;
     }
     public void orderRebellionFleet(StarSystem sys, float enemyFleetSize) {
         if (enemyFleetSize == 0)
@@ -193,25 +275,39 @@ public class AIGeneral implements Base, General {
             setRepelFleetPlan(sys, enemyFleetSize);      
     }
     public void orderInvasionFleet(EmpireView v, StarSystem sys, float enemyFleetSize) {
+        // modnar: scale up invasion multiplier with factories
+        // to account for natural pop growth (enemy transport, etc.) with invasion troop travel time
+        float size = empire.sv.currentSize(sys.id); // planet size
+        float fact = empire.sv.factories(sys.id); // factory count
+        float mult = (1.0f + fact/(10.0f*size)); // invasion multiplier
+        
+        int sysId = sys.id;
+        EmpireView ev = empire.viewForEmpire(empire.sv.empId(sysId));
+        float targetTech = ev.spies().tech().avgTechLevel(); // modnar: target tech level
+        
         if (empire.sv.hasFleetForEmpire(sys.id, empire))
-            launchGroundTroops(v, sys, 1);
+            launchGroundTroops(v, sys, mult);
         else if (empire.combatTransportPct() > 0)
-            launchGroundTroops(v, sys, 1/empire.combatTransportPct());
+            launchGroundTroops(v, sys, mult/empire.combatTransportPct());
 
         float baseBCPresent = empire.sv.bases(sys.id)*empire.tech().newMissileBaseCost();
         float bcMultiplier = 1 + (empire.sv.hostilityLevel(sys.id));
-        float bcNeeded = (baseBCPresent*4) +bcMultiplier*civProd/10;
         
-        // use up to half of BC for Destroyers... rest for fighters
-        int destroyersNeeded = (int) Math.ceil((bcNeeded/2)/empire.shipLab().destroyerDesign().cost());
-        bcNeeded -= (destroyersNeeded * empire.shipLab().destroyerDesign().cost());
-        int fightersNeeded = (int) Math.ceil(bcNeeded/empire.shipLab().fighterDesign().cost());
+        // modnar: include enemyFleetSize, factoring in relative tech levels
+        float bcNeeded = (baseBCPresent*4 + 2*enemyFleetSize)*(targetTech+10.0f)/(civTech+10.0f) + bcMultiplier*civProd/16;
+        
+        // modnar: balance invasion fleet to use 50% destroyers, 30% bombers, and 20% fighters
+        int destroyersNeeded = (int) Math.ceil(0.5f*bcNeeded/empire.shipLab().destroyerDesign().cost());
+        int bombersNeeded = (int) Math.ceil(0.3f*bcNeeded/empire.shipLab().bomberDesign().cost());
+        int fightersNeeded = (int) Math.ceil(0.2f*bcNeeded/empire.shipLab().fighterDesign().cost());
 
         // set fleet orders for invasion...
         ShipDesignLab lab = empire.shipLab();
-        float speed = max(lab.destroyerDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
+        // modnar: should use min speed here (?)
+        float speed = min(lab.destroyerDesign().warpSpeed(), lab.bomberDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
         FleetPlan fp = empire.sv.fleetPlan(sys.id);
         fp.addShips(empire.shipLab().destroyerDesign(), destroyersNeeded);
+        fp.addShips(empire.shipLab().bomberDesign(), bombersNeeded);
         fp.addShips(empire.shipLab().fighterDesign(), fightersNeeded);
         if (v.embassy().finalWar()) 
             fp.priority = FleetPlan.INVADE_FINAL_WAR+ invasionPriority(sys)/100;
@@ -239,11 +335,23 @@ public class AIGeneral implements Base, General {
         for (StarSystem sys : allSystems) {
             if (troopsAvailable < troopsDesired) {
                 float travelTime = sys.colony().transport().travelTime(target);
-                // only consider systems within 3 travel turns
-                if ((travelTime <= 3) && sys.colony().canTransport()) {
+                // modnar: only consider systems within 8 travel turns at the start of the game
+                // decrease with faster warp (faster transport speed)
+                // down to 3 travel turns with warp-9
+                // warp (topSpeed): 1, 2, 3, 4, 5, 6, 7, 8, 9
+                // transport speed: 1, 1, 2, 3, 4, 5, 6, 7, 8
+                // allowableTurns:  8, 8, 8, 6 ,5, 4, 4, 3, 3
+                // max distance:    8, 8,16,18,20,20,24,21,24
+                float topSpeed = empire.tech().topSpeed();
+                float allowableTurns = (float) (1 + Math.min(7, Math.floor(22 / topSpeed)));
+                if ((travelTime <= allowableTurns) && sys.colony().canTransport()) {
                     launchPoints.add(sys);
                     maxTravelTime = max(maxTravelTime, travelTime);
-                    troopsAvailable += sys.colony().maxTransportsAllowed();
+                    // modnar: keep planets at least 60% full
+                    // to prevent complete draining of planets
+                    // TODO: modify with leader personality and source planet fertility
+                    //troopsAvailable += sys.colony().maxTransportsAllowed();
+                    troopsAvailable += Math.max(0.0f, sys.colony().population() - 0.6f*sys.colony().planet().currentSize());
                 }
             }
         }
@@ -257,7 +365,11 @@ public class AIGeneral implements Base, General {
 
         // send transports from launch points
         for (StarSystem sys : launchPoints) {
-            int troops = sys.colony().maxTransportsAllowed();
+            // modnar: keep planets at least 60% full
+            // to prevent complete draining of planets
+            // TODO: modify with leader personality and source planet fertility
+            // int troops = sys.colony().maxTransportsAllowed();
+            int troops = (int) Math.floor(Math.max(0.0f, sys.colony().population() - 0.6f*sys.colony().planet().currentSize()));
             sys.colony().scheduleTransportsToSystem(target, troops, maxTravelTime);
         }
     }
@@ -301,19 +413,47 @@ public class AIGeneral implements Base, General {
     }
     public float troopsNecessaryToTakePlanet(EmpireView ev, StarSystem sys) {
         int id = sys.id;
-        return empire.sv.population(id) * (50 + ev.spies().tech().troopCombatAdj(true)) / (50 + empire.tech().troopCombatAdj(false));
+        
+        // modnar: (?) this old estimate gives completely wrong results for ground combat
+        //return empire.sv.population(id) * (50 + ev.spies().tech().troopCombatAdj(true)) / (50 + empire.tech().troopCombatAdj(false));
+        
+        // modnar: correct ground combat ratio estimates for troopsNecessary
+        if (ev.spies().tech().troopCombatAdj(true) >= empire.tech().troopCombatAdj(false)) {
+            float defAdv = ev.spies().tech().troopCombatAdj(true) - empire.tech().troopCombatAdj(false);
+            // killRatio = attackerCasualties / defenderCasualties
+            float killRatio = (float) ((Math.pow(100,2) - Math.pow(100-defAdv,2)/2) / (Math.pow(100-defAdv,2)/2));
+            return empire.sv.population(id) * killRatio;
+        }
+        else {
+            float atkAdv = empire.tech().troopCombatAdj(false) - ev.spies().tech().troopCombatAdj(true);
+            // killRatio = attackerCasualties / defenderCasualties
+            float killRatio = (float) ((Math.pow(100-atkAdv,2)/2) / (Math.pow(100,2) - Math.pow(100-atkAdv,2)/2));
+            return empire.sv.population(id) * killRatio;
+        }
     }
     public void orderBombardmentFleet(EmpireView v, StarSystem sys, float fleetSize) {
+        
+        int sysId = sys.id;
+        EmpireView ev = empire.viewForEmpire(empire.sv.empId(sysId));
+        float targetTech = ev.spies().tech().avgTechLevel(); // modnar: target tech level
+        
         float baseBCPresent = empire.sv.bases(sys.id)*empire.tech().newMissileBaseCost();
         // set fleet orders for bombardment...
         float bcMultiplier = 1 + (empire.sv.hostilityLevel(sys.id)/2);
-        float bcNeeded = (baseBCPresent*4)+bcMultiplier*civProd/20;
-        int fightersNeeded = (int) Math.ceil(bcNeeded/empire.shipLab().fighterDesign().cost());
-        int bombersNeeded = (int) Math.ceil(4*bcNeeded/empire.shipLab().bomberDesign().cost());
+        
+        // modnar: test fleet sizes, include enemyFleetSize, factoring in relative tech levels
+        float bcNeeded = (baseBCPresent*4 + 2*fleetSize)*(targetTech+10.0f)/(civTech+10.0f) + bcMultiplier*civProd/16;
+        
+        // modnar: bombing fleet to use 50% destroyers, 30% bombers, and 20% fighters
+        int destroyersNeeded = (int) Math.ceil(0.5f*bcNeeded/empire.shipLab().destroyerDesign().cost());
+        int bombersNeeded = (int) Math.ceil(0.3f*bcNeeded/empire.shipLab().bomberDesign().cost());
+        int fightersNeeded = (int) Math.ceil(0.2f*bcNeeded/empire.shipLab().fighterDesign().cost());
 
         ShipDesignLab lab = empire.shipLab();
-        float speed = max(lab.bomberDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
+        // modnar: should use min speed here (?)
+        float speed = min(lab.destroyerDesign().warpSpeed(), lab.bomberDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
         FleetPlan fp = empire.sv.fleetPlan(sys.id);
+        fp.addShips(empire.shipLab().destroyerDesign(), destroyersNeeded);
         fp.addShips(empire.shipLab().bomberDesign(), bombersNeeded);
         fp.addShips(empire.shipLab().fighterDesign(), fightersNeeded);
         fp.stagingPointId = empire.optimalStagingPoint(sys, speed);
@@ -324,14 +464,26 @@ public class AIGeneral implements Base, General {
     }
     public void orderBombEncroachmentFleet(EmpireView v, StarSystem sys, float fleetSize) {
         // set fleet orders for bombardment...
+        int sysId = sys.id;
+        EmpireView ev = empire.viewForEmpire(empire.sv.empId(sysId));
+        float targetTech = ev.spies().tech().avgTechLevel(); // modnar: target tech level
+        
+        float baseBCPresent = empire.sv.bases(sys.id)*empire.tech().newMissileBaseCost();
         float bcMultiplier = 1 + (empire.sv.hostilityLevel(sys.id)/2);
-        float bcNeeded = bcMultiplier*civProd/20;
-        int fightersNeeded = (int) Math.ceil(bcNeeded/empire.shipLab().fighterDesign().cost());
-        int bombersNeeded = (int) Math.ceil(bcNeeded/empire.shipLab().bomberDesign().cost());
+        
+        // modnar: test fleet sizes, include enemyFleetSize, factoring in relative tech levels
+        float bcNeeded = (baseBCPresent*4 + 2*fleetSize)*(targetTech+10.0f)/(civTech+10.0f) + bcMultiplier*civProd/24;
+        
+        // modnar: bombing fleet to use 50% destroyers, 30% bombers, and 20% fighters
+        int destroyersNeeded = (int) Math.ceil(0.5f*bcNeeded/empire.shipLab().destroyerDesign().cost());
+        int bombersNeeded = (int) Math.ceil(0.3f*bcNeeded/empire.shipLab().bomberDesign().cost());
+        int fightersNeeded = (int) Math.ceil(0.2f*bcNeeded/empire.shipLab().fighterDesign().cost());
 
         ShipDesignLab lab = empire.shipLab();
-        float speed = max(lab.bomberDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
+        // modnar: should use min speed here (?)
+        float speed = min(lab.destroyerDesign().warpSpeed(), lab.bomberDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
         FleetPlan fp = empire.sv.fleetPlan(sys.id);
+        fp.addShips(empire.shipLab().destroyerDesign(), destroyersNeeded);
         fp.addShips(empire.shipLab().bomberDesign(), bombersNeeded);
         fp.addShips(empire.shipLab().fighterDesign(), fightersNeeded);
         fp.stagingPointId = empire.optimalStagingPoint(sys, speed);
@@ -341,6 +493,11 @@ public class AIGeneral implements Base, General {
         // pacifist/honorable never sneak attack
         if (empire.leader().isPacifist()
         || empire.leader().isHonorable())
+            return;
+        
+        // modnar: no sneak attack when number of enemies > 2
+        // same as regular war declaration check, significant factor in extra wars
+        if (empire.numEnemies() > 2)
             return;
 
         float baseChance = 0.3f - (empire.numEnemies()*0.3f);
@@ -354,6 +511,20 @@ public class AIGeneral implements Base, General {
         // lower sneak attack chance on planet we can't capture
         if (!empire.canColonize(sys.planet().type()))
                 baseChance -= 0.3f;
+        
+        // modnar: factor in own empire average tech level
+        // suppress sneak attack war in early game when average tech level is below 10
+        float myTechLvl = empire.tech().avgTechLevel(); // minimum average tech level is 1.0
+        float techMod = 1.0f;
+        if (myTechLvl < 10.0f) {
+            techMod = myTechLvl / 20.0f + 0.5f; // linear change with tech level (range from 0.55 to 1.0)
+        }
+        baseChance *= techMod;
+        
+        // modnar: change sneak attack chance by number of our wars vs. number of their wars
+        // try not to get into too many wars, and pile on if target is in many wars
+        float enemyMod = (float) (0.2f * (v.empire().numEnemies() - empire.numEnemies()));
+        baseChance += enemyMod;
 
         float value = (empire.sv.factories(sys.id) * 10);
         float cost = fleetSize + (empire.sv.bases(sys.id)*empire.tech().newMissileBaseCost());
@@ -364,6 +535,26 @@ public class AIGeneral implements Base, General {
             empire.sv.fleetPlan(sys.id).priority = FleetPlan.BOMB_UNDEFENDED;
         }
     }
+    // modnar: setHighFighterGuard added for most threatened
+    private void setHighFighterGuard(StarSystem sys, float priority) {
+        float basesWanted = empire.sv.desiredMissileBases(sys.id);
+        float baseCost = empire.tech().newMissileBase().cost(empire);
+        FleetPlan fp = empire.sv.fleetPlan(sys.id);
+        fp.priority = priority;
+        // modnar: fighter guard on top of any bases, 4 base BC = 1 fighter BC
+        fp.addShipBC(empire.shipLab().fighterDesign(), basesWanted*baseCost/4);
+    }
+    // modnar: setNormalFighterGuard added for possibly threatened
+    private void setNormalFighterGuard(StarSystem sys, float priority) {
+        float basesNeeded = empire.sv.desiredMissileBases(sys.id) - empire.sv.bases(sys.id);
+        if (basesNeeded <= 0) 
+            return;
+        float baseCost = empire.tech().newMissileBase().cost(empire);
+        FleetPlan fp = empire.sv.fleetPlan(sys.id);
+        fp.priority = priority;
+        // modnar: normal fighter guard, 8 base BC = 1 fighter BC
+        fp.addShipBC(empire.shipLab().fighterDesign(), basesNeeded*baseCost/8);
+    }
     private void setMinimumFighterGuard(StarSystem sys, float priority) {
         float basesNeeded = empire.sv.desiredMissileBases(sys.id) - empire.sv.bases(sys.id);
         if (basesNeeded <= 0) 
@@ -371,12 +562,12 @@ public class AIGeneral implements Base, General {
         float baseCost = empire.tech().newMissileBase().cost(empire);
         FleetPlan fp = empire.sv.fleetPlan(sys.id);
         fp.priority = priority;
-        // one base BC = 10 fighter BC
-        fp.addShipBC(empire.shipLab().fighterDesign(), basesNeeded*baseCost/10);
+        // modnar: adjust minium fighter guard, 20 base BC = 1 fighter BC (previous one base BC = 10 fighter BC, typo(?), equation is 10:1)
+        fp.addShipBC(empire.shipLab().fighterDesign(), basesNeeded*baseCost/20); // modnar: reduce minium fighter guard needed
     }
     private void setRepelFleetPlan(StarSystem sys, float fleetSize) {
         float baseBCPresent = empire.sv.bases(sys.id)*empire.tech().newMissileBaseCost();
-        float bcNeeded = max(empire.shipLab().fighterDesign().cost(), fleetSize*10);
+        float bcNeeded = max(empire.shipLab().fighterDesign().cost(), fleetSize*3); // modnar: reduce repel fleet
         bcNeeded -= baseBCPresent;
         if (bcNeeded <= 0)
             return;
@@ -389,7 +580,8 @@ public class AIGeneral implements Base, General {
         int fightersNeeded = (int) Math.ceil(bcNeeded/empire.shipLab().fighterDesign().cost());
 
         ShipDesignLab lab = empire.shipLab();
-        float speed = max(lab.destroyerDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
+        // modnar: should use min speed here (?)
+        float speed = min(lab.destroyerDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
         FleetPlan fp = empire.sv.fleetPlan(sys.id);
         fp.priority = FleetPlan.REPEL + invasionPriority(sys)/100;
         fp.stagingPointId = empire.optimalStagingPoint(sys, speed);
@@ -398,7 +590,7 @@ public class AIGeneral implements Base, General {
     }
     private void setInterceptFleetPlan(StarSystem sys, float fleetSize) {
         float baseBCPresent = empire.sv.bases(sys.id)*empire.tech().newMissileBaseCost();
-        float bcNeeded = max(empire.shipLab().fighterDesign().cost(), fleetSize*6);
+        float bcNeeded = max(empire.shipLab().fighterDesign().cost(), fleetSize*2); // modnar: reduce intercept fleet
         bcNeeded -= baseBCPresent;
         if (bcNeeded <= 0)
             return;
@@ -410,7 +602,8 @@ public class AIGeneral implements Base, General {
         int fightersNeeded = (int) Math.ceil(bcNeeded/empire.shipLab().fighterDesign().cost());
 
         ShipDesignLab lab = empire.shipLab();
-        float speed = max(lab.destroyerDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
+        // modnar: should use min speed here (?)
+        float speed = min(lab.destroyerDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
         FleetPlan fp = empire.sv.fleetPlan(sys.id);
         fp.priority = FleetPlan.INTERCEPT + invasionPriority(sys)/100;
         fp.addShips(empire.shipLab().destroyerDesign(), destroyersNeeded);
@@ -418,7 +611,7 @@ public class AIGeneral implements Base, General {
     }
     private void setExpelFleetPlan(StarSystem sys, float fleetSize) {
         float baseBCPresent = empire.sv.bases(sys.id)*empire.tech().newMissileBaseCost();
-        float bcNeeded = max(empire.shipLab().fighterDesign().cost(), fleetSize*10);
+        float bcNeeded = max(empire.shipLab().fighterDesign().cost(), fleetSize*3); // modnar: reduce expel fleet
         bcNeeded -= baseBCPresent;
         if (bcNeeded <= 0)
             return;
@@ -429,7 +622,8 @@ public class AIGeneral implements Base, General {
         int fightersNeeded = (int) Math.ceil(bcNeeded/empire.shipLab().fighterDesign().cost());
 
         ShipDesignLab lab = empire.shipLab();
-        float speed = max(lab.destroyerDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
+        // modnar: should use min speed here (?)
+        float speed = min(lab.destroyerDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
         FleetPlan fp = empire.sv.fleetPlan(sys.id);
         fp.priority = FleetPlan.EXPEL + invasionPriority(sys)/100;
         fp.stagingPointId = empire.optimalStagingPoint(sys, speed);
@@ -470,7 +664,8 @@ public class AIGeneral implements Base, General {
         int fightersNeeded = (int) Math.ceil(bcNeeded/empire.shipLab().fighterDesign().cost());
 
         ShipDesignLab lab = empire.shipLab();
-        float speed = max(lab.destroyerDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
+        // modnar: should use min speed here (?)
+        float speed = min(lab.destroyerDesign().warpSpeed(), lab.fighterDesign().warpSpeed());
         FleetPlan fp = empire.sv.fleetPlan(sys.id);
         fp.priority = FleetPlan.ASSIST_ALLY + invasionPriority(sys)/100;
         fp.stagingPointId = empire.optimalStagingPoint(sys, speed);

--- a/src/rotp/model/ai/base/AIGovernor.java
+++ b/src/rotp/model/ai/base/AIGovernor.java
@@ -43,9 +43,9 @@ public class AIGovernor implements Base, Governor {
     public boolean readyToBuild(Colony col, ShipPlan sh, int designCost) {
         float pct = col.currentProductionCapacity();
         float estProd = col.industry().factories()*col.planet().productionAdj();
-        if (pct > 0.8)  // at 80% we can build anything
+        if (pct > 0.9)  // modnar: change to 90% to build anything
             return true;
-        else if (pct > 0.7) // at 70, colonize is the lowest priority we can build
+        else if (pct > 0.75) // modnar: change to 75%, colonize is the lowest priority we can build
             return sh.plan.priority() >= FleetPlan.COLONIZE;
         
         return estProd > designCost*5;
@@ -202,7 +202,7 @@ public class AIGovernor implements Base, Governor {
             return;
         }
         
-        // for systems that are flagged as rush defense, do that and forget
+        // for systems that are flagged as rush ship, do that and forget
         // everything else until the project is done
         if (empire.generalAI().rushShipSystems().contains(col.starSystem())) {
             float totalProd = col.totalIncome();
@@ -253,6 +253,24 @@ public class AIGovernor implements Base, Governor {
             col.pct(SHIP, 0);
         }
 
+        // modnar: set 70% research overhead for inner colonies >85% full production
+		// or 20% research overhead for non-inner colonies >90% full production (not just border colonies)
+		// not applicable to rich/ultra-rich
+		// no need to allocate anything here, should be added in automatically to research at the end
+		int bases = (int) col.defense().bases();
+        int maxBases = col.defense().maxBases();
+		float resOverhead = 0.1f*netProd;
+		StarSystem sys = col.starSystem();
+		float prodPct = col.currentProductionCapacity();
+		if (bases >= maxBases) { // only if missile bases are in place
+			if ((prodPct > 0.85) && empire.sv.isInnerSystem(sys.id) && !col.planet().isResourceRich() && !col.planet().isResourceUltraRich()) { 
+				netProd -= 7*resOverhead;
+			}
+			if ((prodPct > 0.9) && !empire.sv.isInnerSystem(sys.id) && !col.planet().isResourceRich() && !col.planet().isResourceUltraRich()) { 
+				netProd -= 2*resOverhead;
+			}
+		}
+		
         // ship spending, if requested
         if (!col.shipyard().buildingObsoleteDesign()
         && (col.shipyard().desiredShips() > 0)
@@ -291,8 +309,8 @@ public class AIGovernor implements Base, Governor {
         if (col.totalAmountAllocated() >= maxAllocation)
             return;
 
-        // def spending gets up to 50% of planet's remaining net prod
-        float defCost = min((netProd * .5f), col.defense().maxSpendingNeeded());
+        // modnar: reduce defense spending, "up to 30%" (previous 50%)
+        float defCost = min((netProd * .3f), col.defense().maxSpendingNeeded());
         col.pct(DEFENSE, defCost/totalProd);
         defCost = col.pct(DEFENSE) * totalProd;
 
@@ -304,8 +322,9 @@ public class AIGovernor implements Base, Governor {
         col.allocation(RESEARCH, maxAllocation - totalAlloc);
 
         // check to allocate reserve
+        // modnar: reduce to 0%, since it's taken care of by the AICTreasurer (?)
         if (col.planet().noArtifacts() && (col.pct(RESEARCH) > 0.5) ) {
-            int rsvAmt = (int) Math.min(.05, col.pct(RESEARCH) - 0.5);
+            int rsvAmt = (int) Math.min(0.0, col.pct(RESEARCH) - 0.5);
             col.addPct(RESEARCH, -rsvAmt);
             col.addPct(INDUSTRY, rsvAmt);
         }
@@ -332,9 +351,9 @@ public class AIGovernor implements Base, Governor {
         if (sys == null)  // this can happen at startup
             col.defense().maxBases(0);
         else if (empire.sv.isAttackTarget(sys.id))
-            col.defense().maxBases(max(currBases, (int)(col.production()/20)));
+            col.defense().maxBases(max(currBases, (int)(col.production()/30))); // modnar: reduce base count
         else if (empire.sv.isBorderSystem(sys.id))
-            col.defense().maxBases(max(currBases, (int)(col.production()/30)));
+            col.defense().maxBases(max(currBases, (int)(col.production()/40))); // modnar: reduce base count
         else
             col.defense().maxBases(max(currBases, (int)(col.production()/50)));
     }

--- a/src/rotp/model/ai/base/AIShipCaptain.java
+++ b/src/rotp/model/ai/base/AIShipCaptain.java
@@ -331,9 +331,11 @@ public class AIShipCaptain implements Base, ShipCaptain {
         }
         
         // if stack is pacted with colony and doesn't want war, then retreat
+        // modnar: change condition to only "doesn't want war"
         if (combat().results().colonyStack != null) {
             EmpireView cv = currStack.empire.viewForEmpire(combat().results().colonyStack.empire);
-            if ((cv != null) && cv.embassy().pact() && !cv.embassy().wantWar())  
+            //if ((cv != null) && cv.embassy().pact() && !cv.embassy().wantWar())
+            if ((cv != null) && !cv.embassy().wantWar())  
                 return true;
         }
 
@@ -396,7 +398,7 @@ public class AIShipCaptain implements Base, ShipCaptain {
         for (CombatStack st1 : friends) {
             float maxKillValue = -1;
             for (CombatStack st2: foes) {
-                float killPct = min(100,st1.estimatedKillPct(st2));
+                float killPct = min(1.0f,st1.estimatedKillPct(st2)); // modnar: killPct should have max of 1.00 instead of 100?
                 float killValue = killPct*st2.num*st2.designCost();
 //                log(st1.name()+"="+killPct+"    "+st2.name());
                 if (killValue > maxKillValue)
@@ -407,7 +409,7 @@ public class AIShipCaptain implements Base, ShipCaptain {
        for (CombatStack st1 : foes) {
             float maxKillValue = -1;
             for (CombatStack st2: friends) {
-                float killPct = min(100,st1.estimatedKillPct(st2));
+                float killPct = min(1.0f,st1.estimatedKillPct(st2)); // modnar: killPct should have max of 1.00 instead of 100?
                 float killValue = killPct*st2.num*st2.designCost();
 //                log(st1.name()+"="+killPct+"    "+st2.name());
                 if (killValue > maxKillValue)
@@ -422,7 +424,7 @@ public class AIShipCaptain implements Base, ShipCaptain {
         else {
             float retreatRatio = stack.empire.leader().retreatRatio(combat().system().empire());
             log("retreat ratio: "+retreatRatio+"   enemyKillValue:"+enemyKills+"  allyKillValue:"+allyKills);
-            return (enemyKills / allyKills) > retreatRatio;
+            return ((enemyKills / allyKills) > retreatRatio/1.2f); // modnar: adjust AI to accept less losses, more likely to retreat
         }
     }
     @Override

--- a/src/rotp/model/ai/base/AIShipDesigner.java
+++ b/src/rotp/model/ai/base/AIShipDesigner.java
@@ -34,6 +34,20 @@ public class AIShipDesigner implements Base, ShipDesigner {
     private static final int OBS_BOMBER_TURNS = 12;
     private static final int OBS_COLONY_TURNS = 8;
     private static final int OBS_SCOUT_TURNS = 1;
+    
+    // modnar: scale military ship obsolete turn counts using the current turn
+    // attempt to allow AI more opportunities to use fleet before scraping
+    // (currentTurn + 100) / (currentTurn + 40))
+    // approx. 2.5 times as long before obsolete at Turn 1
+    // approx. 2.0 times as long before obsolete at Turn 20
+    // approx. 1.5 times as long before obsolete at Turn 80
+    // approx. 1.25 times as long before obsolete at Turn 200
+    private int currentTurn = galaxy().currentTurn();
+    private float obsolete_scale = (float) (currentTurn + 100)/(currentTurn + 40);
+    
+    private int OBS_DESTROYER_TURNS_scale = (int) Math.ceil(OBS_DESTROYER_TURNS * obsolete_scale);
+    private int OBS_FIGHTER_TURNS_scale = (int) Math.ceil(OBS_FIGHTER_TURNS * obsolete_scale);
+    private int OBS_BOMBER_TURNS_scale = (int) Math.ceil(OBS_BOMBER_TURNS * obsolete_scale);
 
     private final Empire empire;
     private int[] shipCounts;
@@ -188,7 +202,7 @@ public class AIShipDesigner implements Base, ShipDesigner {
 
         float oppShield = lab.bestEnemyPlanetaryShieldLevel();
         float bcValue = currDesign.cost()*shipCounts[currDesign.id()];
-        boolean easyToReplace = bcValue <= 100;
+        boolean easyToReplace = bcValue <= 500; // modnar: scrap easier, change from 100
         
         if (easyToReplace) {
             newDesign.name(currDesign.name());
@@ -217,7 +231,7 @@ public class AIShipDesigner implements Base, ShipDesigner {
             return;
 
         // mark existing design obsolete
-        currDesign.becomeObsolete(OBS_BOMBER_TURNS);
+        currDesign.becomeObsolete(OBS_BOMBER_TURNS_scale); // modnar: use scaled OBS_TURNS
 
         // check for an available slot for the new design
         int slot = lab.availableDesignSlot();
@@ -263,7 +277,7 @@ public class AIShipDesigner implements Base, ShipDesigner {
         // if we have very few fighters actually in use, go ahead and
         // scrap/replace now
         float bcValue = currDesign.cost()*shipCounts[currDesign.id()];
-        boolean easyToReplace = bcValue <= 100;
+        boolean easyToReplace = bcValue <= 500; // modnar: scrap easier, change from 100
         
         if (easyToReplace) {
             newDesign.name(currDesign.name());
@@ -290,7 +304,7 @@ public class AIShipDesigner implements Base, ShipDesigner {
             return;
 
         // mark existing design obsolete
-        currDesign.becomeObsolete(OBS_FIGHTER_TURNS);
+        currDesign.becomeObsolete(OBS_FIGHTER_TURNS_scale); // modnar: use scaled OBS_TURNS
 
         // check for an available slot for the new design
         int slot = lab.availableDesignSlot();
@@ -337,7 +351,7 @@ public class AIShipDesigner implements Base, ShipDesigner {
         // if we have very few destroyers actually in use, go ahead and
         // scrap/replace now
         float bcValue = currDesign.cost()*shipCounts[currDesign.id()];
-        boolean easyToReplace = bcValue <= 1000;
+        boolean easyToReplace = bcValue <= 2000; // modnar: scrap easier, change from 1000
         
         if (easyToReplace) {
             newDesign.name(currDesign.name());
@@ -363,7 +377,7 @@ public class AIShipDesigner implements Base, ShipDesigner {
             return;
      
         // mark existing design obsolete
-        currDesign.becomeObsolete(OBS_DESTROYER_TURNS);
+        currDesign.becomeObsolete(OBS_DESTROYER_TURNS_scale); // modnar: use scaled OBS_TURNS
 
         // check for an available slot for the new design
         int slot = lab.availableDesignSlot();
@@ -446,9 +460,9 @@ public class AIShipDesigner implements Base, ShipDesigner {
         int maxSize = ShipDesign.SMALL;
         if (maxProd >= 1500)
             maxSize = ShipDesign.HUGE;
-        else if (maxProd >= 300)
+        else if (maxProd >= 700) // modnar: change from 300, keep fighters smaller
             maxSize = ShipDesign.LARGE;
-        else if (maxProd >= 60)
+        else if (maxProd >= 300) // modnar: change from 60 (!), keep fighters smaller
             maxSize = ShipDesign.MEDIUM;
         return min(preferredSize, maxSize);
     }
@@ -464,9 +478,9 @@ public class AIShipDesigner implements Base, ShipDesigner {
             maxProd = max(sys.colony().production(), maxProd);
 
         int maxSize = ShipDesign.MEDIUM;
-        if (maxProd >= 1000)
+        if (maxProd >= 1500) // modnar: change from 1000, keep bombers smaller
             maxSize = ShipDesign.HUGE;
-        else if (maxProd >= 200)
+        else if (maxProd >= 450) // modnar: change from 200, keep bombers smaller
             maxSize = ShipDesign.LARGE;
         return min(preferredSize, maxSize);
     }
@@ -482,9 +496,9 @@ public class AIShipDesigner implements Base, ShipDesigner {
             maxProd = max(sys.colony().production(), maxProd);
 
         int maxSize = ShipDesign.MEDIUM;
-        if (maxProd >= 1000)
+        if (maxProd >= 800) // modnar: change from 1000, pump out HUGE destroyers sooner, 800 is around soil/terraform+40/robo-4
             maxSize = ShipDesign.HUGE;
-        else if (maxProd >= 200)
+        else if (maxProd >= 350) // modnar: change from 200, keep destroyer smaller in beginning
             maxSize = ShipDesign.LARGE;
         return min(preferredSize, maxSize);
     }
@@ -492,21 +506,21 @@ public class AIShipDesigner implements Base, ShipDesigner {
     public ShipDesign newFighterDesign(int size) {
         ShipDesign design = ShipFighterTemplate.newDesign(this);
         design.mission(ShipDesign.FIGHTER);
-        design.maxUnusedTurns(OBS_FIGHTER_TURNS);
+        design.maxUnusedTurns(OBS_FIGHTER_TURNS_scale); // modnar: use scaled OBS_TURNS
         return design;
     }
     @Override
     public ShipDesign newBomberDesign(int size) {
         ShipDesign design = ShipBomberTemplate.newDesign(this);
         design.mission(ShipDesign.BOMBER);
-        design.maxUnusedTurns(OBS_BOMBER_TURNS);
+        design.maxUnusedTurns(OBS_BOMBER_TURNS_scale); // modnar: use scaled OBS_TURNS
         return design;
     }
     @Override
     public ShipDesign newDestroyerDesign(int size) {
         ShipDesign design = ShipDestroyerTemplate.newDesign(this);
         design.mission(ShipDesign.DESTROYER);
-        design.maxUnusedTurns(OBS_DESTROYER_TURNS);
+        design.maxUnusedTurns(OBS_DESTROYER_TURNS_scale); // modnar: use scaled OBS_TURNS
         return design;
     }
     @Override

--- a/src/rotp/model/ai/base/AISpyMaster.java
+++ b/src/rotp/model/ai/base/AISpyMaster.java
@@ -37,6 +37,9 @@ public class AISpyMaster implements Base, SpyMaster {
         // invoked after nextTurn() processing is complete on each civ's turn
         // also invoked when contact is made in mid-turn
         // return from 0 to 40, which translates to 0% to 20% of total prod
+        //
+        // modnar: is it not 0% to 10% of total prod, for a max of +20% security bonus, with 0 to 10 ticks/clicks?
+        // MAX_SECURITY_TICKS = 10 in model/empires/Empire.java
 
         int paranoia = 0;
         boolean alone = true;
@@ -44,16 +47,16 @@ public class AISpyMaster implements Base, SpyMaster {
             if ((cv != null) && cv.embassy().contact()) {
                 alone = false;
                 if (cv.embassy().anyWar())
-                    paranoia += 2;
+                    paranoia += 3; // modnar: more internal security paranoia
                 if (cv.embassy().noTreaty())
-                    paranoia++;
+                    paranoia += 2; // modnar: more internal security paranoia
             }
         }
         if ((paranoia == 0) && !alone)
             paranoia++;
         if (empire.leader().isXenophobic())
             paranoia *= 2;
-        return min(40, paranoia);
+        return min(10, paranoia); // modnar: change max to 10, MAX_SECURITY_TICKS = 10
     }
     @Override
     public void setSpyingAllocation(EmpireView v) {
@@ -70,21 +73,30 @@ public class AISpyMaster implements Base, SpyMaster {
         int maxSpiesNeeded;
 
         if (v.embassy().finalWar())
-            maxSpiesNeeded = 3;
+            // modnar: reduce spies needed for large number of active empires
+            maxSpiesNeeded = galaxy().numActiveEmpires() > 20 ? 2 : 3;
         else if (v.embassy().war())
-            maxSpiesNeeded = 2;
-        else if (v.embassy().noTreaty())
-            maxSpiesNeeded = 1;
+            // modnar: reduce spies needed for large number of active empires
+            maxSpiesNeeded = galaxy().numActiveEmpires() > 20 ? 1 : 2;
+        else if (v.embassy().noTreaty()) {
+            // modnar: check if empire is in range or not
+            if (v.empire().inEconomicRange(id(empire)))
+                maxSpiesNeeded = 1;
+            else
+                maxSpiesNeeded = 0; // modnar: no spies if not in range
+        }
         else if (v.embassy().pact())
-            maxSpiesNeeded = 1;
+            // modnar: reduce spies needed for large number of active empires
+            maxSpiesNeeded = galaxy().numActiveEmpires() > 20 ? 0 : 1;
         else   // unity() or alliance()
             maxSpiesNeeded = 0;
 
-        // 1% (2 ticks) spending for each spy needed
+        // modnar: reduce allocation to 1 tick per spy needed, better for larger games with more empires
+        // 0.5% (1 tick) spending for each spy needed
         if (v.spies().numActiveSpies() >= maxSpiesNeeded)
             v.spies().allocation(0);
         else
-            v.spies().allocation(maxSpiesNeeded * 2);
+            v.spies().allocation(maxSpiesNeeded * 1);
     }
     @Override
     public void setSpyingMission(EmpireView v) {

--- a/src/rotp/model/ai/base/ShipFighterTemplate.java
+++ b/src/rotp/model/ai/base/ShipFighterTemplate.java
@@ -24,6 +24,7 @@ import rotp.model.empires.EmpireView;
 import rotp.model.ships.ShipArmor;
 import rotp.model.ships.ShipComputer;
 import rotp.model.ships.ShipDesign;
+import rotp.model.ships.ShipECM;
 import rotp.model.ships.ShipManeuver;
 import rotp.model.ships.ShipShield;
 import rotp.model.ships.ShipSpecial;
@@ -91,14 +92,21 @@ public class ShipFighterTemplate implements Base {
         ShipDesign d = ai.lab().newBlankDesign(size);
         setFastestEngine(ai, d);
         float totalSpace = d.availableSpace();
-        setBestBattleComputer(ai, d);
         setBestCombatSpeed(ai, d);
-        if (d.size() >= ShipDesign.MEDIUM) 
-            setBestNormalArmor(ai, d);
-            
+        if (d.size() >= ShipDesign.SMALL) {
+            setBestNormalArmor(ai, d);  // normal armor for all sizes
+            set2ndBestBattleComputer(ai, d); // set 2nd best battle computer for smaller ships
+        }
+        
+        if (d.size() == ShipDesign.MEDIUM) {
+            set2ndBestShield(ai, d); // give 2nd best shield for MEDIUM
+        }
+        
         if (d.size() >= ShipDesign.LARGE) {
+            setBestBattleComputer(ai, d);
             setBattleScanner(ai, d);
             setBestShield(ai, d);
+            set2ndBestECMJammer(ai, d); // give 2nd best ECM to LARGE and HUGE
         }
 
         float weaponSpace = d.availableSpace();
@@ -152,6 +160,32 @@ public class ShipFighterTemplate implements Base {
                 return;
         }
     }
+ // add 2nd best battle computer option
+    private void set2ndBestBattleComputer(ShipDesigner ai, ShipDesign d) {
+        List<ShipComputer> comps = ai.lab().computers();
+        for (int i=comps.size()-2; i >=0; i--) {
+            d.computer(comps.get(i));
+            if (d.availableSpace() >= 0)
+                return;
+        }
+    }
+    private void setBestECMJammer(ShipDesigner ai, ShipDesign d) {
+        List<ShipECM> comps = ai.lab().ecms();
+        for (int i=comps.size()-1; i >=0; i--) {
+            d.ecm(comps.get(i));
+            if (d.availableSpace() >= 0)
+                return;
+        }
+    }
+ // add 2nd best ECM option
+    private void set2ndBestECMJammer(ShipDesigner ai, ShipDesign d) {
+        List<ShipECM> comps = ai.lab().ecms();
+        for (int i=comps.size()-2; i >=0; i--) {
+            d.ecm(comps.get(i));
+            if (d.availableSpace() >= 0)
+                return;
+        }
+    }
     private void setBestNormalArmor(ShipDesigner ai, ShipDesign d) {
         List<ShipArmor> armors = ai.lab().armors();
         for (int i=armors.size()-1; i >=0; i--) {
@@ -166,6 +200,15 @@ public class ShipFighterTemplate implements Base {
     private void setBestShield(ShipDesigner ai, ShipDesign d) {
         List<ShipShield> shields = ai.lab().shields();
         for (int i=shields.size()-1; i >=0; i--) {
+            d.shield(shields.get(i));
+            if (d.availableSpace() >= 0)
+                return;
+        }
+    }
+     // add 2nd best shield option
+    private void set2ndBestShield(ShipDesigner ai, ShipDesign d) {
+        List<ShipShield> shields = ai.lab().shields();
+        for (int i=shields.size()-2; i >=0; i--) {
             d.shield(shields.get(i));
             if (d.availableSpace() >= 0)
                 return;


### PR DESCRIPTION
Hey Ray, here are the Dev-AI improvements from my MOD.

All the changes did end up in the AI classes. I was recalling stuff that was outside of it, but forgot that a lot of them were in the previous pull requests (like ships not suiciding against planets in ShipDesignLab or correct troopKillRatio formula in Empire).

Here's a list of all the changes:

**AIDiplomat.java**

- limit one tech trade per empire per turn
- asymptotically less likely to get into war if already in some wars (does not prevent instant wars)
- more likely to declare war of hate if target is in more wars than we are
- change war of opportunity to be based on our current average tech level, less likely if tech level too low
- more likely to declare war of opportunity if target is in more wars than we are
- reduce basePower and baseThreshold for war of opportunity due to previous two changes
- some previous galactic council voting changes were already included (powerBonus1, relations() normalization)
- galactic council voting changed to this comment ( https://reddit.com/r/rotp/comments/l2wpuk/question_about_ai_and_councilvoting_question_in/gk947xt/ )
- boost giveLoyaltyTo with powerBonus that is the relative power between elected empire and own empire. different than the voting powerBonus1, which is candidate power relative to whole galaxy
- scale the expansion penalty with ~1/[(numCivs)^(0.75)] rather than 1/numCivs, described in more detail here ( https://reddit.com/r/rotp/comments/i45obb/rotp_development_ai_testing_my_updateschanges/ )
- scale warWeary by the number of our wars vs the number of target's wars


**AIFleetCommander.java**

- keep inExpansionMode if not in any contact
- if a fleet plan can be filled, then fill and send out right away. allows for multi-design fleets


**AIGeneral.java**

- more complex invasion valuation and priority, allows for more accurate troop invasion calculations and more aggressive troop invasions
- still always keep troop origin planet at least 60% full, don't drain our planets
- use correct ground combat casualty estimation formula
- travel time for troop invasions re-worked (should "work" with new fast warp option, allowableTurns would just be one turn)
- allow invasion/bombard fleets to have combined designs
- adjust amount of invasion/bombard fleets according to enemy fleet present, enemy tech level, and our tech level (in addition to bases present and our production)
- don't considerSneakAttackFleet if already in at least 2 wars
- lower considerSneakAttackFleet chance if we're at a low average tech level
- change considerSneakAttackFleet based on the number of our wars vs the number of target's wars


**AIGovernor.java**

- increase readyToBuild percentage, more efficient
- set research overhead for certain colonies, gives more focus on research
- slightly reduce bases needed


**AIScientist.java**

- use modified tech opening book, mainly for range and waste cleanup techs
- adjust tech valuation for several tech types, warp speed, range tech, robotic control, ship weapons
- some comment typo fixes


**AIShipCaptain.java**

- remove pact requirement for wantToRetreat
- correct killPct value
- ship captain accept less losses, more likely to retreat


**AIShipDesigner.java**

- scale obsolete turn counts to be higher near beginning of game, when techs aren't coming in fast
- increase immediate scrapping threshold
- keep fighters smaller
- keep bombers smaller
- keep destroyers smaller at lower productions, allow huge destroyers slightly sooner


**AISpyMaster.java**

- general reduction in spying
- increase in internal security paranoia


**AITreasurer.java**

- flip rich vs poor system in terms of getting reserve spending
- should be giving reserve to poor and taking reserve from rich
- reduce amount of desiredRsv, more efficient


**Ship Templates**

- many small adjustments to bomber/destroyer/fighter ship templates
- make bomber and destroyer more general purpose (bomber carry more regular weapons, destroyers carry some bombs)
- while general purpose ships are likely less efficient than specialized ships, it'll be easier for the ai to better use general purpose ships
- *should do overhaul to be a more probabilistic system like in moo1, to hopefully get more access to special modules and weapons
