### PR TITLE
 Bug fixes and AI enhancements for transports.

### DIFF
--- a/src/rotp/model/ai/base/AIGeneral.java
+++ b/src/rotp/model/ai/base/AIGeneral.java
@@ -285,10 +285,15 @@ public class AIGeneral implements Base, General {
         EmpireView ev = empire.viewForEmpire(empire.sv.empId(sysId));
         float targetTech = ev.spies().tech().avgTechLevel(); // modnar: target tech level
         
-        if (empire.sv.hasFleetForEmpire(sys.id, empire))
+        if (empire.sv.orbitingFleet(sys.id) != null)
             launchGroundTroops(v, sys, mult);
-        else if (empire.combatTransportPct() > 0)
-            launchGroundTroops(v, sys, mult/empire.combatTransportPct());
+        else if (empire.combatTransportPct() > 0) {
+            float transPct = empire.combatTransportPct();
+            if (ev.spies().tech().subspaceInterdiction()) {
+                transPct /= 2;
+            }
+            launchGroundTroops(v, sys, mult / transPct);
+        }
 
         float baseBCPresent = empire.sv.bases(sys.id)*empire.tech().newMissileBaseCost();
         float bcMultiplier = 1 + (empire.sv.hostilityLevel(sys.id));

--- a/src/rotp/model/colony/Colony.java
+++ b/src/rotp/model/colony/Colony.java
@@ -269,14 +269,13 @@ public final class Colony implements Base, IMappedObject, Serializable {
     public float population()             { return population; }
     private void population(float pop)    { population = pop; }
     public int setPopulation(float pop) {
-        float newPop = population() + pop;
         float currentMaxPop = planet().currentSize();
-        float lost = newPop - currentMaxPop;
+        float lost = pop - currentMaxPop;
         if (lost > 0) {
             population(currentMaxPop);
             return (int) lost;
         }
-        population(newPop);
+        population(pop);
         return 0;
     }
     public float adjustPopulation(float pop) {

--- a/src/rotp/model/colony/Colony.java
+++ b/src/rotp/model/colony/Colony.java
@@ -951,7 +951,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
             empire.setVisibleShips();
     }
     public void acceptTransport(Transport t) {
-        if (adjustPopulation(t.size()) > 0) {
+        if ((adjustPopulation(t.size()) > 0) && t.empire().isPlayerControlled()) {
             // TODO: Some transports lost because max population was reached. Ought to be an alert?
         }
         log("Accepting ", str(t.size()), " transports at: ", starSystem().name(), ". New pop:", fmt(population(), 2));


### PR DESCRIPTION
1. Fixes the method for setting colony population to ensure enforcement of the planet's current maximum size. Addresses a number of possible bugs (some observed) as per impacts to:
  a) Colony.capturedByTransport: Eliminates ability to massively overpopulate a captured colony, *and then potentially forward-transport excess colonists, including in a cascading attack sequence*. Since the game does not cap the maximum number of transports than can land in a ground attack the way MOO1 did, this can result in the ability for a single colony to send a quantity of transports far in excess of any amount that would be allowable even for the best possible maximally terraformed gaia planet.
  b) Colony.capturedOrion: (same considerations as capturedByTransport).
  c) Empire.takeAbandonedSystem: It appears that it was previously possible to assign an arbitrarily large population when acquiring an abandoned colony.
  d) ColonyEcology.commitTurn: (Theoretical) Capping growth to the planet currentSize limit appears to rely entirely on the prior population growth and purchase calculations being done (i.e. constrained) correctly. Based on IDE-assisted search for uses of setPopulation, there is no turn-processing logic for fallback enforcement of the currentSize limit in the event of errors in the calculations. No indications have been encountered of this working incorrectly at this time, but still... brittle.
     i) NOTE: The check for setting the populationGrowthCompleted flag also appears possibly flawed as it seems to check against the maximum possible size when all terraforming available to the empire has been applied, as opposed to the amount that has *actually* been applied to the planet. Unclear as to what the impact might be, and thus whether this behaves as intended for whatever consumes this flag.
  - Also applied by incorporation to the adjustPopulation method, with corresponding updates to use the adjust method instead of set when appropriate.
  - Provided a return value to indicate transports lost due to exceeding the colony max size, and left placeholders for what should probably be notifications to the player when this happens. Not yet sure how to provide the translations for the prospective notification though (Google translate?).

2. Fixes scheduleTransportsToSystem to actually constrain to the maximum amount allowed. (The computed value "xPop" was not actually being used. But it was what was logged!)

3. Fixes logic for determining that the attacker has a fleet in control of the target system, when not using combat transporters. The previous logic was only checking that the empire had a fleet "at" the target system. Unfortunately this led to a (observed) situation where an opponent repeatedly sent large numbers of transports to their certain death, because it would find that a fleet it had sent was at the system. But unfortanately for them, a fleet that has retreated is still considered "at" the system in a deployed (not orbiting) state -- and they kept retreating their fleets because they were not sending anywhere near the force necessary to displace the fleet I was holding in orbit at the system.

4. When relying on combat transporters, adjust force size for the effect of the target having subspace interdictors if indicated by available spy intelligence.