### PR TITLE
Improve check for fleet control before launching ground troops.

### DIFF
--- a/src/rotp/model/ai/base/AIGeneral.java
+++ b/src/rotp/model/ai/base/AIGeneral.java
@@ -284,8 +284,8 @@ public class AIGeneral implements Base, General {
         int sysId = sys.id;
         EmpireView ev = empire.viewForEmpire(empire.sv.empId(sysId));
         float targetTech = ev.spies().tech().avgTechLevel(); // modnar: target tech level
-        
-        if (empire.sv.hasFleetForEmpire(sys.id, empire))
+
+        if (empire.sv.orbitingFleet(sys.id) != null)
             launchGroundTroops(v, sys, mult);
         else if (empire.combatTransportPct() > 0) {
             // adj pct if enemy has subspace interdictors: fix by ajkfreelance


### PR DESCRIPTION
Fixes AI logic for determining that it has a fleet in control of the target system when not relying on combat transporters. The previous logic was only checking that the empire had a fleet "at" the target system, but this internal state includes the case where a fleet has retreated but not yet left the system. Unfortunately this led to a (observed) situation where an opponent kept trying to send transports with no chance of survival because it would send a fleet to a target system, auto-retreat it due to power imbalance, but still launch the transports.