### PR TITLE
Enforce max transports as intended.

### DIFF
--- a/src/rotp/model/colony/Colony.java
+++ b/src/rotp/model/colony/Colony.java
@@ -947,7 +947,7 @@ public final class Colony implements Base, IMappedObject, Serializable {
         if ((dest == starSystem()) || (xPop == 0))
             clearTransport();
         else {
-            transport().size(pop);
+            transport().size(xPop);
             transport().setDest(dest);
             transport().setDefaultTravelSpeed();
         }


### PR DESCRIPTION
The number of transports sent is only capped for logging purposes, not
actual functional effect.