### PR TITLE
Add command-line option to change configuration/savefile directory

### DIFF
--- a/src/rotp/Rotp.java
+++ b/src/rotp/Rotp.java
@@ -42,7 +42,7 @@ public class Rotp {
     public static String jarFileName = "Remnants.jar";
     public static String exeFileName = "Remnants.exe";
     public static boolean countWords = false;
-    private static String startupDir;
+    private static String startupDir = System.getProperty("startupdir");
     private static JFrame frame;
     public static String releaseId = "1.02a";
     public static long startMs = System.currentTimeMillis();


### PR DESCRIPTION
```java -jar -Dstartupdir=/home/username/.config/Remnants/ Remnants.jar``` would save Remnants.cfg and recent.rotp at ```/home/usernaame/.config/Remnants/``` for example.

Adding this command line argument would make sandboxing ROTP very easy. This would make packaging ROTP as a flatpak possible too, in case @rayfowler is interested.